### PR TITLE
Use connection ID as key for WebTransportSessions.

### DIFF
--- a/web_transport/sdk/impl/web_transport_server_backend.h
+++ b/web_transport/sdk/impl/web_transport_server_backend.h
@@ -7,6 +7,7 @@
 #ifndef OWT_QUIC_WEB_TRANSPORT_WEB_TRANSPORT_SERVER_BACKEND_H_
 #define OWT_QUIC_WEB_TRANSPORT_WEB_TRANSPORT_SERVER_BACKEND_H_
 
+#include "base/threading/thread_checker.h"
 #include "impl/web_transport_server_session.h"
 #include "net/third_party/quiche/src/quic/core/http/web_transport_http3.h"
 #include "net/third_party/quiche/src/quic/core/web_transport_interface.h"
@@ -40,11 +41,12 @@ class WebTransportServerBackend : public WebTransportSessionVisitor {
 
  private:
   WebTransportServerInterface::Visitor* visitor_;
-  std::unordered_map<::quic::WebTransportSessionId,
-                     std::unique_ptr<WebTransportServerSession>>
+  // Key is HTTP/3 QUIC stream connection ID.
+  std::unordered_map<std::string, std::unique_ptr<WebTransportServerSession>>
       sessions_;
   base::SingleThreadTaskRunner* io_runner_;
   base::SingleThreadTaskRunner* event_runner_;
+  base::ThreadChecker io_thread_checker_;
 
   DISALLOW_COPY_AND_ASSIGN(WebTransportServerBackend);
 };

--- a/web_transport/sdk/impl/web_transport_server_session.cc
+++ b/web_transport/sdk/impl/web_transport_server_session.cc
@@ -108,7 +108,8 @@ uint64_t WebTransportServerSession::SessionId() const {
 }
 
 const char* WebTransportServerSession::ConnectionId() const {
-  const std::string& session_id_str = std::to_string(SessionId());
+  const std::string& session_id_str =
+      http3_session_->connection_id().ToString();
   char* id = new char[session_id_str.size() + 1];
   strcpy(id, session_id_str.c_str());
   return id;


### PR DESCRIPTION
WebTrannsportSessionId is not unique for all the sessions associated
with a certain server. It starts from 0 for each connection. The old
session is destoryed when a new session with the same ID is created.

As we only allow a single WebTransport session for a QUIC connection,
it's safe to use QUIC connection ID as key.