### PR TITLE
Add const qualifier to the first argument of Write method.

### DIFF
--- a/web_transport/sdk/api/owt/quic/web_transport_stream_interface.h
+++ b/web_transport/sdk/api/owt/quic/web_transport_stream_interface.h
@@ -33,7 +33,7 @@ class OWT_EXPORT WebTransportStreamInterface {
   virtual void SetVisitor(Visitor* visitor) = 0;
   // Write or buffer data. Returns the length of data written or buffered.
   // Current implementation always returns 0 or `length`.
-  virtual size_t Write(uint8_t* data, size_t length) = 0;
+  virtual size_t Write(const uint8_t* data, size_t length) = 0;
   // Reads at most `length` bytes into `data` and returns the number of bytes
   // actually read.
   virtual size_t Read(uint8_t* data, size_t length) = 0;

--- a/web_transport/sdk/impl/web_transport_stream_impl.cc
+++ b/web_transport/sdk/impl/web_transport_stream_impl.cc
@@ -58,7 +58,7 @@ uint32_t WebTransportStreamImpl::Id() const {
   return stream_->GetStreamId();
 }
 
-size_t WebTransportStreamImpl::Write(uint8_t* data, size_t length) {
+size_t WebTransportStreamImpl::Write(const uint8_t* data, size_t length) {
   DCHECK_EQ(sizeof(uint8_t), sizeof(char));
   CHECK(io_runner_);
   if (io_runner_->BelongsToCurrentThread()) {
@@ -71,11 +71,11 @@ size_t WebTransportStreamImpl::Write(uint8_t* data, size_t length) {
   io_runner_->PostTask(
       FROM_HERE,
       base::BindOnce(
-          [](WebTransportStreamImpl* stream, uint8_t* data, size_t& length,
+          [](WebTransportStreamImpl* stream, const uint8_t* data, size_t& length,
              bool& result, base::WaitableEvent* event) {
             if (stream->stream_->CanWrite()) {
-              result = stream->stream_->Write(
-                  absl::string_view(reinterpret_cast<char*>(data), length));
+              result = stream->stream_->Write(absl::string_view(
+                  reinterpret_cast<const char*>(data), length));
             } else {
               result = false;
             }

--- a/web_transport/sdk/impl/web_transport_stream_impl.h
+++ b/web_transport/sdk/impl/web_transport_stream_impl.h
@@ -41,7 +41,7 @@ class WebTransportStreamImpl : public WebTransportStreamInterface,
   void SetVisitor(
       owt::quic::WebTransportStreamInterface::Visitor* visitor) override;
   uint32_t Id() const override;
-  size_t Write(uint8_t* data, size_t length) override;
+  size_t Write(const uint8_t* data, size_t length) override;
   size_t Read(uint8_t* data, size_t length) override;
   size_t ReadableBytes() const override;
   void Close() override;


### PR DESCRIPTION
The pointer to data doesn't need to be changed. Making it const so it
can accept pointer casted from std::string.