### PR TITLE
Add a new event OnDatagramReceived for WebTransportServerSession.

### DIFF
--- a/web_transport/sdk/api/owt/quic/web_transport_session_interface.h
+++ b/web_transport/sdk/api/owt/quic/web_transport_session_interface.h
@@ -21,6 +21,7 @@ class OWT_EXPORT WebTransportSessionInterface {
     virtual void OnIncomingStream(WebTransportStreamInterface*) = 0;
     virtual void OnCanCreateNewOutgoingStream(bool unidirectional) = 0;
     virtual void OnConnectionClosed() = 0;
+    virtual void OnDatagramReceived(const uint8_t* data, size_t length) = 0;
   };
   virtual ~WebTransportSessionInterface() = default;
   virtual const char* ConnectionId() const = 0;

--- a/web_transport/sdk/impl/tests/web_transport_echo_visitors.h
+++ b/web_transport/sdk/impl/tests/web_transport_echo_visitors.h
@@ -35,6 +35,7 @@ class SessionEchoVisitor : public WebTransportSessionInterface::Visitor {
   void OnCanCreateNewOutgoingStream(bool) override {}
   void OnConnectionClosed() override {}
   void OnIncomingStream(WebTransportStreamInterface* stream) override;
+  void OnDatagramReceived(const uint8_t* data, size_t length) override {}
 
  private:
   std::vector<std::unique_ptr<StreamEchoVisitor>> stream_visitors_;

--- a/web_transport/sdk/impl/web_transport_server_session.cc
+++ b/web_transport/sdk/impl/web_transport_server_session.cc
@@ -224,5 +224,12 @@ void WebTransportServerSession::AcceptIncomingStream(
   }
 }
 
+void WebTransportServerSession::OnDatagramReceived(absl::string_view datagram) {
+  if (visitor_) {
+    visitor_->OnDatagramReceived(
+        reinterpret_cast<const uint8_t*>(datagram.data()), datagram.size());
+  }
+}
+
 }  // namespace quic
 }  // namespace owt

--- a/web_transport/sdk/impl/web_transport_server_session.h
+++ b/web_transport/sdk/impl/web_transport_server_session.h
@@ -50,7 +50,7 @@ class WebTransportServerSession : public WebTransportSessionInterface,
                        const std::string& error_message) override;
   void OnIncomingBidirectionalStreamAvailable() override;
   void OnIncomingUnidirectionalStreamAvailable() override;
-  void OnDatagramReceived(absl::string_view datagram) override {}
+  void OnDatagramReceived(absl::string_view datagram) override;
   void OnCanCreateNewOutgoingUnidirectionalStream() override {}
   void OnCanCreateNewOutgoingBidirectionalStream() override {}
 


### PR DESCRIPTION
This is a breaking change as a new pure virtual function `OnDatagramReceived` is added to `WebTransportSessionInterface::Visitor`. All derived classes must implement this function.