### PR TITLE
Roll clang to 15.

### DIFF
--- a/test/scripts/build.py
+++ b/test/scripts/build.py
@@ -26,7 +26,11 @@ SDK_TARGETS = ['owt_web_transport']
 TEST_TARGETS = ['owt_web_transport_tests']
 TEST_TARGETS_WIN = ['owt_web_transport_dll_tests']
 PATCH_LIST = [
-    ('0001-Add-owt_web_transport-to-BUILD.gn.patch', SRC_PATH)
+    ('0001-Add-owt_web_transport-to-BUILD.gn.patch', SRC_PATH),
+    ('0002-build-Relanding-Rudimentary-support-for-Visual-Studi.patch', SRC_PATH),
+    ('0003-Update-generate-certs.sh-to-use-ECDSA.patch', SRC_PATH),
+    ('0004-Roll-clang-llvmorg-14-init-8564-g34b903d8-2-llvmorg-.patch', SRC_PATH),
+    ('0005-Fix-compiling-issues-after-upgrading-clang-to-15.patch', SRC_PATH)
 ]
 GIT_BIN = 'git.bat' if sys.platform == 'win32' else 'git'
 

--- a/test/scripts/build.py
+++ b/test/scripts/build.py
@@ -33,10 +33,15 @@ PATCH_LIST = [
     ('0005-Fix-compiling-issues-after-upgrading-clang-to-15.patch', SRC_PATH)
 ]
 GIT_BIN = 'git.bat' if sys.platform == 'win32' else 'git'
+GCLIENT_BIN = 'gclient.bat' if sys.platform == 'win32' else 'gclient'
 
 def sync():
-    gclient_bin = 'gclient.bat' if sys.platform == 'win32' else 'gclient'
-    if subprocess.call([gclient_bin, 'sync', '--reset'], cwd=SRC_PATH, shell=False):
+    if subprocess.call([GCLIENT_BIN, 'sync', '--reset'], cwd=SRC_PATH, shell=False):
+        return False
+    return True
+
+def run_hooks():
+   if subprocess.call([GCLIENT_BIN, 'runhooks'], cwd=SRC_PATH, shell=False):
         return False
     return True
 
@@ -146,6 +151,8 @@ def main():
     if not sync():
         return 1
     patch()
+    if not run_hooks():
+        return 1
     create_gclient_args()
     setup_environment_variables()
     if not build():

--- a/web_transport/docs/build_instructions.md
+++ b/web_transport/docs/build_instructions.md
@@ -37,6 +37,8 @@ Some manually changes to Chromium code are needed before building SDK.
 
 1. Apply patches in `owt/web_transport/patches` to `src` directory.
 
+1. Run `git fetch https://android.googlesource.com/platform/external/perfetto.git d8081faeb0e9264d0343208d9a2325525bb90832 && git checkout FETCH_HEAD` in `src/third_party/perfetto` directory.
+
 1. Create a file `gclient_args.gni` in `build/config` with following code.
 
 ```

--- a/web_transport/docs/build_instructions.md
+++ b/web_transport/docs/build_instructions.md
@@ -35,7 +35,7 @@ You will see a `src` directory after sync completes. Switch to the `src` directo
 
 Some manually changes to Chromium code are needed before building SDK.
 
-1. Add `"//owt/web_transport:owt_web_transport",` to `BUILD.gn`, after line 104. You need to revert this change before rolling Chromium revision, and redo this change after rolling.
+1. Apply patches in `owt/web_transport/patches` to `src` directory.
 
 1. Create a file `gclient_args.gni` in `build/config` with following code.
 

--- a/web_transport/patches/0001-Add-owt_web_transport-to-BUILD.gn.patch
+++ b/web_transport/patches/0001-Add-owt_web_transport-to-BUILD.gn.patch
@@ -1,14 +1,14 @@
-From 1d409ac32a4381e43d0b67d08bedfabac91da371 Mon Sep 17 00:00:00 2001
+From f2a513d78caf635e5786be41aeaaf688f23f50dc Mon Sep 17 00:00:00 2001
 From: Jianjun Zhu <jianjun.zhu@intel.com>
 Date: Sat, 30 Oct 2021 00:20:39 +0800
-Subject: [PATCH] Add owt_web_transport to BUILD.gn.
+Subject: [PATCH 1/5] Add owt_web_transport to BUILD.gn.
 
 ---
  BUILD.gn | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/BUILD.gn b/BUILD.gn
-index fe0ed6dd1b584..963d0df64a453 100644
+index 8b6f4bf90557a..5ed8919d17662 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
 @@ -101,6 +101,7 @@ group("gn_all") {
@@ -20,5 +20,5 @@ index fe0ed6dd1b584..963d0df64a453 100644
  
    if (!is_component_build) {
 -- 
-2.33.1
+2.33.0.windows.2
 

--- a/web_transport/patches/0002-build-Relanding-Rudimentary-support-for-Visual-Studi.patch
+++ b/web_transport/patches/0002-build-Relanding-Rudimentary-support-for-Visual-Studi.patch
@@ -1,0 +1,152 @@
+From 55c25a8ec55837c1ccfdbca10c06a15c6f2a2665 Mon Sep 17 00:00:00 2001
+From: Bruce Dawson <brucedawson@chromium.org>
+Date: Tue, 21 Dec 2021 16:19:32 +0000
+Subject: [PATCH 2/5] build: Relanding Rudimentary support for Visual Studio
+ 2022.
+
+This CL patches vs_toolchain.py to handle an installed version of
+Visual Studio 2022. This is a necessary first step towards supporting
+VS2022, but it's not sufficient. There are no guarantees that the
+MSVC143 toolchain produces acceptable results.
+
+Visual Studio 2022 is the first 64-bit edition, so it is installed in
+C:\Program Files\, not C:\Program Files (x86)\. Handling both VS2022 and
+older versions introduces a bit of extra complexity in the path
+detection code. We'll be able to remove this complexity when we remove
+support for VS2019 and below.
+
+This was originally landed as crrev.com/c/3316095 but that change broke
+arm64 builds because this change inadvertently changed the toolset
+version for prepackaged toolchains which arm64 use to find the UCRT.
+
+Tested: Full build with Visual Studio 2022 Professional retail, gn gen
+of x64 and arm64 with packaged toolchain.
+
+Bug: 1277518
+Change-Id: Ic942ba82a71799bbe14dc64e4e640d9d36e62b22
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3351095
+Reviewed-by: Victor Costan <pwnall@chromium.org>
+Reviewed-by: Peter Wen <wnwen@chromium.org>
+Commit-Queue: Bruce Dawson <brucedawson@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#953228}
+---
+ build/vs_toolchain.py              | 58 ++++++++++++++++++------------
+ docs/windows_build_instructions.md |  8 +++--
+ 2 files changed, 40 insertions(+), 26 deletions(-)
+
+diff --git a/build/vs_toolchain.py b/build/vs_toolchain.py
+index ecf0971ab1349..e759bd6ca2afe 100755
+--- a/build/vs_toolchain.py
++++ b/build/vs_toolchain.py
+@@ -39,15 +39,20 @@ script_dir = os.path.dirname(os.path.realpath(__file__))
+ json_data_file = os.path.join(script_dir, 'win_toolchain.json')
+ 
+ # VS versions are listed in descending order of priority (highest first).
++# The first version is assumed by this script to be the one that is packaged,
++# which makes a difference for the arm64 runtime.
+ MSVS_VERSIONS = collections.OrderedDict([
+-  ('2019', '16.0'),
+-  ('2017', '15.0'),
++    ('2019', '16.0'),  # Default and packaged version of Visual Studio.
++    ('2022', '17.0'),
++    ('2017', '15.0'),
+ ])
+ 
+ # List of preferred VC toolset version based on MSVS
++# Order is not relevant for this dictionary.
+ MSVC_TOOLSET_VERSION = {
+-   '2019' : 'VC142',
+-   '2017' : 'VC141',
++    '2022': 'VC143',
++    '2019': 'VC142',
++    '2017': 'VC141',
+ }
+ 
+ def _HostIsWindows():
+@@ -167,13 +172,17 @@ def GetVisualStudioVersion():
+     # Checking vs%s_install environment variables.
+     # For example, vs2019_install could have the value
+     # "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community".
+-    # Only vs2017_install and vs2019_install are supported.
++    # Only vs2017_install, vs2019_install and vs2022_install are supported.
+     path = os.environ.get('vs%s_install' % version)
+     if path and os.path.exists(path):
+       available_versions.append(version)
+       break
+     # Detecting VS under possible paths.
+-    path = os.path.expandvars('%ProgramFiles(x86)%' +
++    if version >= '2022':
++      program_files_path_variable = '%ProgramFiles%'
++    else:
++      program_files_path_variable = '%ProgramFiles(x86)%'
++    path = os.path.expandvars(program_files_path_variable +
+                               '/Microsoft Visual Studio/%s' % version)
+     if path and any(
+         os.path.exists(os.path.join(path, edition))
+@@ -200,23 +209,26 @@ def DetectVisualStudioPath():
+   # the registry. For details see:
+   # https://blogs.msdn.microsoft.com/heaths/2016/09/15/changes-to-visual-studio-15-setup/
+   # For now we use a hardcoded default with an environment variable override.
+-  for path in (
+-      os.environ.get('vs%s_install' % version_as_year),
+-      os.path.expandvars('%ProgramFiles(x86)%' +
+-                         '/Microsoft Visual Studio/%s/Enterprise' %
+-                         version_as_year),
+-      os.path.expandvars('%ProgramFiles(x86)%' +
+-                         '/Microsoft Visual Studio/%s/Professional' %
+-                         version_as_year),
+-      os.path.expandvars('%ProgramFiles(x86)%' +
+-                         '/Microsoft Visual Studio/%s/Community' %
+-                         version_as_year),
+-      os.path.expandvars('%ProgramFiles(x86)%' +
+-                         '/Microsoft Visual Studio/%s/Preview' %
+-                         version_as_year),
+-      os.path.expandvars('%ProgramFiles(x86)%' +
+-                         '/Microsoft Visual Studio/%s/BuildTools' %
+-                         version_as_year)):
++  if version_as_year >= '2022':
++    program_files_path_variable = '%ProgramFiles%'
++  else:
++    program_files_path_variable = '%ProgramFiles(x86)%'
++  for path in (os.environ.get('vs%s_install' % version_as_year),
++               os.path.expandvars(program_files_path_variable +
++                                  '/Microsoft Visual Studio/%s/Enterprise' %
++                                  version_as_year),
++               os.path.expandvars(program_files_path_variable +
++                                  '/Microsoft Visual Studio/%s/Professional' %
++                                  version_as_year),
++               os.path.expandvars(program_files_path_variable +
++                                  '/Microsoft Visual Studio/%s/Community' %
++                                  version_as_year),
++               os.path.expandvars(program_files_path_variable +
++                                  '/Microsoft Visual Studio/%s/Preview' %
++                                  version_as_year),
++               os.path.expandvars(program_files_path_variable +
++                                  '/Microsoft Visual Studio/%s/BuildTools' %
++                                  version_as_year)):
+     if path and os.path.exists(path):
+       return path
+ 
+diff --git a/docs/windows_build_instructions.md b/docs/windows_build_instructions.md
+index 2cfd0f7cebb81..83de36d71a69e 100644
+--- a/docs/windows_build_instructions.md
++++ b/docs/windows_build_instructions.md
+@@ -90,10 +90,12 @@ Also, add a DEPOT_TOOLS_WIN_TOOLCHAIN system variable in the same way, and set
+ it to 0. This tells depot_tools to use your locally installed version of Visual
+ Studio (by default, depot_tools will try to use a google-internal version).
+ 
+-You may also have to set variable `vs2017_install` or `vs2019_install` to your
+-installation path of Visual Studio 2017 or 19, like
++You may also have to set variable `vs2017_install` or `vs2019_install` or
++`vs2022_install` to your installation path of Visual Studio 2017 or 19 or 22, like
+ `set vs2019_install=C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional`
+-for Visual Studio 2019.
++for Visual Studio 2019, or
++`set vs2022_install=C:\Program Files\Microsoft Visual Studio\2022\Professional`
++for Visual Studio 2022.
+ 
+ From a cmd.exe shell, run:
+ 
+-- 
+2.33.0.windows.2
+

--- a/web_transport/patches/0003-Update-generate-certs.sh-to-use-ECDSA.patch
+++ b/web_transport/patches/0003-Update-generate-certs.sh-to-use-ECDSA.patch
@@ -1,0 +1,37 @@
+From 143d1d128d0a8e1884cf1874a3f222d3c0dcafe7 Mon Sep 17 00:00:00 2001
+From: Jianjun Zhu <jianjun.zhu@intel.com>
+Date: Thu, 7 Apr 2022 10:43:23 +0800
+Subject: [PATCH 3/5] Update generate-certs.sh to use ECDSA.
+
+RSA is not supported when using serverCertificateHashes.
+See
+https://www.w3.org/TR/webtransport/#dom-webtransportoptions-servercertificatehashes.
+---
+ net/tools/quic/certs/generate-certs.sh | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/net/tools/quic/certs/generate-certs.sh b/net/tools/quic/certs/generate-certs.sh
+index 11dde0703a60d..a296323134a33 100755
+--- a/net/tools/quic/certs/generate-certs.sh
++++ b/net/tools/quic/certs/generate-certs.sh
+@@ -18,7 +18,7 @@ try /bin/sh -c "echo 01 > out/2048-sha256-root-serial"
+ touch out/2048-sha256-root-index.txt
+ 
+ # Generate the key.
+-try openssl genrsa -out out/2048-sha256-root.key 2048
++try openssl ecparam -genkey -name prime256v1 -out out/2048-sha256-root.key
+ 
+ # Generate the root certificate.
+ try openssl req \
+@@ -38,6 +38,8 @@ try openssl x509 \
+ # Generate the leaf certificate request.
+ try openssl req \
+   -new \
++  -newkey ec\
++  -pkeyopt ec_paramgen_curve:prime256v1\
+   -keyout out/leaf_cert.key \
+   -out out/leaf_cert.req \
+   -config leaf.cnf
+-- 
+2.33.0.windows.2
+

--- a/web_transport/patches/0004-Roll-clang-llvmorg-14-init-8564-g34b903d8-2-llvmorg-.patch
+++ b/web_transport/patches/0004-Roll-clang-llvmorg-14-init-8564-g34b903d8-2-llvmorg-.patch
@@ -1,0 +1,28 @@
+From ff2ff6d9d87858fe4b0ac4800b098f7f14c2dd31 Mon Sep 17 00:00:00 2001
+From: Jianjun Zhu <jianjun.zhu@intel.com>
+Date: Mon, 27 Jun 2022 19:31:34 +0800
+Subject: [PATCH 4/5] Roll clang llvmorg-14-init-8564-g34b903d8-2 :
+ llvmorg-15-init-13850-ge2913362-1
+
+---
+ tools/clang/scripts/update.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/clang/scripts/update.py b/tools/clang/scripts/update.py
+index 9a8bae564d9a7..4198f07dbbb4f 100755
+--- a/tools/clang/scripts/update.py
++++ b/tools/clang/scripts/update.py
+@@ -34,8 +34,8 @@ import zipfile
+ # https://chromium.googlesource.com/chromium/src/+/main/docs/updating_clang.md
+ # Reverting problematic clang rolls is safe, though.
+ # This is the output of `git describe` and is usable as a commit-ish.
+-CLANG_REVISION = 'llvmorg-14-init-8564-g34b903d8'
+-CLANG_SUB_REVISION = 2
++CLANG_REVISION = 'llvmorg-15-init-13850-ge2913362'
++CLANG_SUB_REVISION = 1
+ 
+ PACKAGE_VERSION = '%s-%s' % (CLANG_REVISION, CLANG_SUB_REVISION)
+ RELEASE_VERSION = '14.0.0'
+-- 
+2.33.0.windows.2
+

--- a/web_transport/patches/0005-Fix-compiling-issues-after-upgrading-clang-to-15.patch
+++ b/web_transport/patches/0005-Fix-compiling-issues-after-upgrading-clang-to-15.patch
@@ -1,0 +1,110 @@
+From b1fb11f50d936a7730e1a16360cfff75d641d7f8 Mon Sep 17 00:00:00 2001
+From: Jianjun Zhu <jianjun.zhu@intel.com>
+Date: Tue, 28 Jun 2022 10:12:22 +0800
+Subject: [PATCH 5/5] Fix compiling issues after upgrading clang to 15.
+
+---
+ DEPS                                | 2 +-
+ base/third_party/libevent/strlcpy.c | 5 +----
+ build/config/compiler/BUILD.gn      | 1 +
+ net/cert/crl_set.cc                 | 2 +-
+ net/quic/quic_stream_factory.cc     | 2 +-
+ third_party/zlib/BUILD.gn           | 8 ++++++--
+ 6 files changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/DEPS b/DEPS
+index d1c1e54704310..156f3f0e791fe 100644
+--- a/DEPS
++++ b/DEPS
+@@ -1412,7 +1412,7 @@ deps = {
+   },
+ 
+   'src/third_party/perfetto':
+-    Var('android_git') + '/platform/external/perfetto.git' + '@' + '856b76580ea2b35f3ec45254524f0de61eff2bd7',
++    Var('android_git') + '/platform/external/perfetto.git' + '@' + 'd8081faeb0e9264d0343208d9a2325525bb90832',
+ 
+   'src/third_party/perl': {
+       'url': Var('chromium_git') + '/chromium/deps/perl.git' + '@' + '6f3e5028eb65d0b4c5fdd792106ac4c84eee1eb3',
+diff --git a/base/third_party/libevent/strlcpy.c b/base/third_party/libevent/strlcpy.c
+index 5d194527c8caa..149fee5d99e67 100644
+--- a/base/third_party/libevent/strlcpy.c
++++ b/base/third_party/libevent/strlcpy.c
+@@ -46,10 +46,7 @@ static char *rcsid = "$OpenBSD: strlcpy.c,v 1.5 2001/05/13 15:40:16 deraadt Exp
+  * Returns strlen(src); if retval >= siz, truncation occurred.
+  */
+ size_t
+-_event_strlcpy(dst, src, siz)
+-	char *dst;
+-	const char *src;
+-	size_t siz;
++_event_strlcpy(char *dst, const char *src, size_t siz)
+ {
+ 	register char *d = dst;
+ 	register const char *s = src;
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index 2656f800f7da4..2c04accabc64e 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1574,6 +1574,7 @@ config("chromium_code") {
+     if (is_clang) {
+       # Enable extra warnings for chromium_code when we control the compiler.
+       cflags += [ "-Wextra" ]
++      cflags += [ "-Wno-unused-but-set-variable" ]
+     }
+ 
+     # In Chromium code, we define __STDC_foo_MACROS in order to get the
+diff --git a/net/cert/crl_set.cc b/net/cert/crl_set.cc
+index 908a099cc053a..5ecb0e7ee2ff2 100644
+--- a/net/cert/crl_set.cc
++++ b/net/cert/crl_set.cc
+@@ -243,7 +243,7 @@ bool CRLSet::Parse(base::StringPiece data, scoped_refptr<CRLSet>* out_crl_set) {
+   crl_set->not_after_ = static_cast<uint64_t>(not_after);
+   crl_set->crls_.reserve(64);  // Value observed experimentally.
+ 
+-  for (size_t crl_index = 0; !data.empty(); crl_index++) {
++  while (!data.empty()) {
+     std::string spki_hash;
+     std::vector<std::string> blocked_serials;
+ 
+diff --git a/net/quic/quic_stream_factory.cc b/net/quic/quic_stream_factory.cc
+index 9336c7d92d321..24f6f1f485ce8 100644
+--- a/net/quic/quic_stream_factory.cc
++++ b/net/quic/quic_stream_factory.cc
+@@ -1068,7 +1068,7 @@ QuicStreamRequest::ReleaseSessionHandle() {
+ 
+ void QuicStreamRequest::SetSession(
+     std::unique_ptr<QuicChromiumClientSession::Handle> session) {
+-  session_ = move(session);
++  session_ = std::move(session);
+ }
+ 
+ QuicStreamFactory::QuicSessionAliasKey::QuicSessionAliasKey(
+diff --git a/third_party/zlib/BUILD.gn b/third_party/zlib/BUILD.gn
+index 49f52e1f8b1e5..d53173ba803c6 100644
+--- a/third_party/zlib/BUILD.gn
++++ b/third_party/zlib/BUILD.gn
+@@ -197,6 +197,7 @@ source_set("zlib_inflate_chunk_simd") {
+   # style function declarations, which triggers warning C4131.
+   configs -= [ "//build/config/compiler:chromium_code" ]
+   configs += [ "//build/config/compiler:no_chromium_code" ]
++  configs += [ ":zlib_warnings" ]
+ 
+   public_configs = [ ":zlib_inflate_chunk_simd_config" ]
+ 
+@@ -266,8 +267,11 @@ source_set("zlib_x86_simd") {
+ }
+ 
+ config("zlib_warnings") {
+-  if (is_clang && use_x86_x64_optimizations) {
+-    cflags = [ "-Wno-incompatible-pointer-types" ]
++  if (is_clang) {
++    cflags = [ "-Wno-deprecated-non-prototype" ]
++    if (use_x86_x64_optimizations) {
++      cflags += [ "-Wno-incompatible-pointer-types" ]
++    }
+   }
+ }
+ 
+-- 
+2.33.0.windows.2
+


### PR DESCRIPTION
This change fixes some compiling issues with the latest VS2022. It also
update script to generate certificate with ECDSA as RSA is not supported
by browser.